### PR TITLE
Fix the lack of bash closes #4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 
 # RUNNER
 
-FROM alpine:3.16.0 AS runtime
+FROM linuxcontainers/debian-slim:12.5 AS runtime
 
 LABEL maintainer=dp24@sanger.ac.uk
 


### PR DESCRIPTION
Alpine doesn't ship with bash so adding the container to Nextflow, in this case running tests on a sanger-tol-module, will end in failure.

Swapped Alpine for Debian slim, which I've confirmed to have bash by running:
```
docker run -it sha256:ffa7bf8f1a04cc0a7b2f9e4642b89b37136ed27f530914fe3d38ae85051f4097 bash

root@f076b541c5ee:/# bash -v
# System-wide .bashrc file for interactive bash(1) shells.
...

root@bc4a6082d310:/# touch hello.txt
```

KMER counter also works
```
root@f076b541c5ee:/# kmer-counter
kmer-counter
error: The following required arguments were not provided:
    --file <file>

USAGE:
    kmer-counter [OPTIONS] --file <file>

For more information try --help
```