### PR TITLE
Add procps package to Dockerfile dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 ENV CARGO_TARGET_DIR=/usr/local/kmer-counter
 
 RUN apt-get update && \
-    apt-get install -y musl-tools pkg-config libssl-dev && \
+    apt-get install -y musl-tools pkg-config libssl-dev procps && \
     rustup target add x86_64-unknown-linux-musl
 
 RUN rustup target add x86_64-unknown-linux-musl


### PR DESCRIPTION
ps (PROCPS) is needed by nextflow in order to collect resource stats.

Tested locally
```
root@821a6ea658a5:/# ps
  PID TTY          TIME CMD
    1 pts/0    00:00:00 bash
 1521 pts/0    00:00:00 ps
 ```